### PR TITLE
Port to reqwest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Cargo.lock
 
 /target/
 /obj/
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "elastic_reqwest"
 version = "0.1.0"
-authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
+authors = ["Ashley Mannix <ashleymannix@live.com.au>", "Stephan Buys <stephan.buys@gmail.com>"]
 license = "Apache-2.0"
 description = "A lightweight implementation of the Elasticsearch API based on Reqwest, derived from elastic-hyper."
 #documentation = "https://docs.rs/elastic_types/0.4.0/elastic_hyper/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name = "elastic_hyper"
-version = "0.4.0"
+name = "elastic_reqwest"
+version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
-description = "A lightweight implementation of the Elasticsearch API based on Hyper."
-documentation = "https://docs.rs/elastic_types/0.4.0/elastic_hyper/"
-repository = "https://github.com/elastic-rs/elastic-hyper"
+description = "A lightweight implementation of the Elasticsearch API based on Reqwest, derived from elastic-hyper."
+#documentation = "https://docs.rs/elastic_types/0.4.0/elastic_hyper/"
+#repository = "https://github.com/elastic-rs/elastic-hyper"
 exclude = [ "samples" ]
 
-[features]
-default = [ "ssl" ]
-ssl = [ "hyper/ssl" ]
+#[features]
+#default = [ "ssl" ]
+#ssl = [ "hyper/ssl" ]
 
 [dependencies]
 elastic_requests = "~0.1.0"
-hyper = { version = "~0.9.0", default-features = false }
-url = "~1.1.0"
+reqwest = "*"
+url = "*"
 
 [dev-dependencies]
-json_str = "^0.*"
+json_str = "*"

--- a/samples/basic/Cargo.toml
+++ b/samples/basic/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 nightly-testing = []
 
 [dependencies]
-elastic_hyper = { version = "*", path = "../../" }
+elastic_reqwest = { version = "*", path = "../../" }
 elastic_requests = "*"
 json_str = "*"
 hyper = "~0.9.0"

--- a/samples/basic/Cargo.toml
+++ b/samples/basic/Cargo.toml
@@ -10,4 +10,4 @@ nightly-testing = []
 elastic_reqwest = { version = "*", path = "../../" }
 elastic_requests = "*"
 json_str = "*"
-hyper = "~0.9.0"
+

--- a/samples/basic/src/main.rs
+++ b/samples/basic/src/main.rs
@@ -1,4 +1,4 @@
-//! Elasticsearch Hyper Client Samples
+//! Elasticsearch Reqwest Client Samples
 //!
 //! This sample assumes you have a node running on `localhost`.
 //!
@@ -7,17 +7,17 @@
 
 #[macro_use]
 extern crate json_str;
-extern crate hyper;
-extern crate elastic_hyper;
+extern crate elastic_reqwest;
 extern crate elastic_requests;
 
-use elastic_hyper::{ElasticClient, RequestParams};
+use elastic_reqwest::{ElasticClient, RequestParams};
 use elastic_requests::SearchRequest;
-use hyper::client::Client;
 use std::io::Read;
 
 fn main() {
-    let cli = Client::new();
+
+    let (client, _) = elastic_reqwest::default();
+
     let params = RequestParams::default().url_params(vec![("pretty", String::from("true"))]);
 
     let body = json_str!({
@@ -28,7 +28,7 @@ fn main() {
         }
     });
 
-    let mut res = cli.elastic_req(&params, SearchRequest::for_index("_all", body)).unwrap();
+    let mut res = client.elastic_req(&params, SearchRequest::for_index("_all", body)).unwrap();
 
     let mut message = String::new();
     res.read_to_string(&mut message).unwrap();

--- a/samples/typed/Cargo.toml
+++ b/samples/typed/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 nightly-testing = []
 
 [dependencies]
-hyper = "~0.9.0"
-elastic_hyper = { version = "*", path = "../../" }
+reqwest = "*"
+elastic_reqwest = { version = "*", path = "../../" }
 elastic_requests = "*"
 elastic_types = { version = "*", features = ["nightly"]}
 elastic_types_derive = "*"

--- a/samples/typed/src/main.rs
+++ b/samples/typed/src/main.rs
@@ -10,7 +10,7 @@
 
 extern crate serde;
 extern crate serde_json;
-extern crate hyper;
+extern crate reqwest;
 
 #[macro_use]
 extern crate serde_derive;
@@ -19,12 +19,12 @@ extern crate elastic_types_derive;
 
 #[macro_use]
 extern crate elastic_types;
-extern crate elastic_hyper;
+extern crate elastic_reqwest;
 extern crate elastic_requests;
 
 use std::net::Ipv4Addr;
-use hyper::Client;
-use elastic_hyper::{ElasticClient, RequestParams};
+use reqwest::Client;
+use elastic_reqwest::{ElasticClient, RequestParams};
 use elastic_requests::{IndicesCreateRequest, IndexRequest, SearchRequest};
 use elastic_types::prelude::*;
 
@@ -36,8 +36,8 @@ use response::*;
 const INDEX: &'static str = "testidx";
 
 fn main() {
-    // Create a hyper client
-    let client = Client::new();
+    // Create a new client
+    let (client, _) = elastic_reqwest::default();
 
     // Default request parameters
     let params = RequestParams::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //!
 //! Ping the availability of your cluster:
 //!
-//! ```
+//! ```no_run
 //! //HTTP HEAD /
 //!
 //! # extern crate elastic_requests as req;
@@ -66,7 +66,7 @@
 //!
 //! Execute a search query with a url parameter:
 //!
-//! ```
+//! ```no_run
 //! //HTTP GET /myindex/mytype/_search?q='my string'
 //!
 //! extern crate reqwest;
@@ -97,7 +97,7 @@
 //! Using the [`json_str`](http://kodraus.github.io/rustdoc/json_str/) crate, you can execute
 //! queries using pure json:
 //!
-//! ```
+//! ```no_run
 //! //HTTP POST /myindex/mytype/_search
 //!
 //! #

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,14 +1,13 @@
-extern crate hyper;
+extern crate reqwest;
 extern crate url;
-extern crate elastic_hyper;
+extern crate elastic_reqwest;
 
-use hyper::header::*;
-use elastic_hyper::RequestParams;
+use reqwest::header::*;
+use elastic_reqwest::RequestParams;
 
 #[test]
 fn request_params_has_default_content_type() {
 	let req = RequestParams::default();
-
 	assert_eq!(Some(&ContentType::json()), req.headers.get::<ContentType>());
 }
 


### PR DESCRIPTION
Hi Ashley (@KodrAus), here is a port of `elastic-hyper` to `elastic-reqwest` for your consideration. I did this to get to know your codebase a bit better, and because I kept failing to compile your code due to `MacOS Sierra`'s horrible `openssl` situation. `reqwest` is almost identical to `hyper`'s client but it avoids `openssl` and uses native `ssl`. It's probably a more complete/mature version of the lessons learned from `hyper`'s client.