### PR TITLE
Add an example of customising the ES cluster url

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ let (client, params) = cli::default();
 client.elastic_req(&params, PingRequest::new()).unwrap();
 ```
 
+Customise the location of the Elasticsearch cluster:
+ 
+ ```rust
+ let (mut client, mut params) = elastic::default();
+ params.base_url = String::from("http://eshost:9200");
+ ```
+
 A query DSL query:
 
 ```rust


### PR DESCRIPTION
Simple addition of an example.