### PR TITLE
Never copy req body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_reqwest"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>", "Stephan Buys <stephan.buys@gmail.com>"]
 license = "Apache-2.0"
 description = "A lightweight implementation of the Elasticsearch API based on reqwest."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/elastic-rs/elastic-hyper"
 exclude = [ "samples" ]
 
 [dependencies]
-elastic_requests = "~0.1.2"
+elastic_requests = "~0.1.3"
 reqwest = "~0.2.0"
 url = "~1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ extern crate reqwest;
 extern crate url;
 
 use elastic_requests::*;
-use std::borrow::Cow;
+use std::borrow::{Cow, Borrow};
 use std::collections::BTreeMap;
 use std::io::Cursor;
 use std::str;
@@ -284,8 +284,6 @@ impl Default for RequestParams {
 pub fn default() -> Result<(reqwest::Client, RequestParams), reqwest::Error> {
     reqwest::Client::new().map(|cli| (cli, RequestParams::default()))
 }
-
-use std::borrow::Borrow;
 
 macro_rules! req_with_body {
     ($client:ident, $url:ident, $body:ident, $params:ident, $method:ident) => ({

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,19 +289,9 @@ macro_rules! req_with_body {
     ($client:ident, $url:ident, $body:ident, $params:ident, $method:ident) => ({
         let body = $body.expect("Expected this request to have a body. This is a bug, please file an issue on GitHub.");
 
-        let body = match body {
-            Cow::Borrowed(b) => {
-                match **b {
-                    Cow::Borrowed(b) => reqwest::Body::new(Cursor::new(b)),
-                    Cow::Owned(ref b) => reqwest::Body::new(Cursor::new(b))
-                }
-            },
-            Cow::Owned(b) => {
-                match b.into() {
-                    Cow::Borrowed(b) => reqwest::Body::new(Cursor::new(b)),
-                    Cow::Owned(b) => b.into()
-                }
-            }
+        let body = match body.into_raw() {
+            Cow::Borrowed(b) => reqwest::Body::new(Cursor::new(b)),
+            Cow::Owned(b) => b.into()
         };
 
         $client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ extern crate reqwest;
 extern crate url;
 
 use elastic_requests::*;
-use std::borrow::{Cow, Borrow};
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::io::Cursor;
 use std::str;


### PR DESCRIPTION
Fixes #13.

I might leave this here for a bit to decide whether or not I'm happy with it. It feels a bit leaky. It'd be good to add a method to `HttpRequest<'a>` in `elastic_requests` that will give a single `Cow<'a, [u8]>` using this same approach, so everything but an owned body with owned data returns a `Cow::Borrowed`.
It could also be done with a trait implemented by `Cow<'a, Body<'a>>`. Point is it should probably be `elastic_request`s job to wrap this.