### PR TITLE
Add bulk sample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ script:
       travis-cargo bench &&
       cd samples/basic &&
       travis-cargo build &&
+      cd ../bulk &&
+      travis-cargo build &&
       cd ../typed &&
       travis-cargo --only nightly build &&
       cd ../../ &&

--- a/samples/basic/Cargo.toml
+++ b/samples/basic/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "elastic_hyper_samples"
+name = "basic"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 

--- a/samples/basic/src/main.rs
+++ b/samples/basic/src/main.rs
@@ -15,11 +15,14 @@ use elastic_requests::SearchRequest;
 use std::io::Read;
 
 fn main() {
-
+    // Get a new default client.
     let (client, _) = elastic_reqwest::default().unwrap();
 
-    let params = RequestParams::default().url_params(vec![("pretty", String::from("true"))]);
+    // Create a new set of params with pretty printing.
+    let params = RequestParams::default().
+        url_params(vec![("pretty", String::from("true"))]);
 
+    // Create a query DSL request body.
     let body = json_str!({
         query: {
             query_string: {
@@ -28,6 +31,7 @@ fn main() {
         }
     });
 
+    // Send the request and read the response.
     let mut res = client.elastic_req(&params, SearchRequest::for_index("_all", body)).unwrap();
 
     let mut message = String::new();

--- a/samples/bulk/.gitignore
+++ b/samples/bulk/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/obj/

--- a/samples/bulk/Cargo.toml
+++ b/samples/bulk/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "elastic_hyper_samples"
+name = "bulk"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 

--- a/samples/bulk/Cargo.toml
+++ b/samples/bulk/Cargo.toml
@@ -3,8 +3,11 @@ name = "elastic_hyper_samples"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 
+[features]
+profiling = []
+
 [dependencies]
 elastic_reqwest = { version = "*", path = "../../" }
 elastic_requests = "*"
 
-json_str = "*"
+lazy_static = { version = "*", optional = true }

--- a/samples/bulk/src/main.rs
+++ b/samples/bulk/src/main.rs
@@ -1,0 +1,72 @@
+//! Elasticsearch Reqwest Client Samples
+//!
+//! This sample assumes you have a node running on `localhost`.
+//! 
+//! This sample demonstrates a request with a large body.
+//! 
+//! If you compile with `--features profiling` then it uses the system allocator 
+//! to play nicely with valgrind for profiling.
+//! 
+//! If you compile with `--features lazy_static` then the sample uses a borrowed
+//! request instead of an owned one.
+//! This will avoid allocating multiple copies of the request if the same body
+//! is used multiple times.
+
+#![cfg_attr(feature="profiling", feature(alloc_system))]
+#[cfg(feature="profiling")]
+extern crate alloc_system;
+
+#[cfg(feature="lazy_static")]
+#[cfg_attr(feature = "lazy_static", macro_use)]
+extern crate lazy_static;
+
+extern crate elastic_requests;
+extern crate elastic_reqwest;
+
+use elastic_reqwest::ElasticClient;
+use elastic_requests::BulkRequest;
+
+// Create a bulk request to index a bunch of docs.
+macro_rules! bulk_req {
+    () => ({
+        let mut bulk = String::new();
+        for i in 1..1000 {
+            let header = format!("{{ \"index\" : {{ \"_index\" : \"test\", \"_type\" : \"ty\", \"_id\" : \"{}\" }} }}", i);
+            let body = format!("{{ \"title\" : \"string value {}\" }}", i);
+
+            bulk.push_str(&header);
+            bulk.push('\n');
+            bulk.push_str(&body);
+            bulk.push('\n');
+        }
+
+        BulkRequest::new(bulk)
+    })
+}
+
+#[cfg(feature="lazy_static")]
+lazy_static! {
+    static ref REQUEST: BulkRequest<'static> = {
+        bulk_req!()
+    };
+}
+
+#[cfg(not(feature="lazy_static"))]
+fn get_req() -> BulkRequest<'static> {
+    bulk_req!()
+}
+
+#[cfg(feature="lazy_static")]
+fn get_req() -> &'static BulkRequest<'static> {
+    &REQUEST
+}
+
+fn main() {
+    // Get a new default client.
+    let (client, params) = elastic_reqwest::default().unwrap();
+
+    // Send the bulk request.
+    let res = client.elastic_req(&params, get_req()).unwrap();
+
+    println!("{:?}", res);
+}

--- a/samples/typed/Cargo.toml
+++ b/samples/typed/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "elastic_hyper_samples"
+name = "typed"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 
@@ -7,6 +7,7 @@ authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 elastic_reqwest = { version = "*", path = "../../" }
 elastic_requests = "*"
 
+reqwest = "~0.2.0"
 serde = "~0.8.0"
 serde_derive = "~0.8.0"
 serde_json = "~0.8.0"

--- a/samples/typed/Cargo.toml
+++ b/samples/typed/Cargo.toml
@@ -3,16 +3,14 @@ name = "elastic_hyper_samples"
 version = "0.1.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 
-[features]
-nightly-testing = []
-
 [dependencies]
-reqwest = "*"
 elastic_reqwest = { version = "*", path = "../../" }
 elastic_requests = "*"
-elastic_types = { version = "*", features = ["nightly"]}
-elastic_types_derive = "*"
-json_str = { version = "*", features = ["nightly"]}
+
 serde = "~0.8.0"
 serde_derive = "~0.8.0"
 serde_json = "~0.8.0"
+elastic_types = { version = "*", features = ["nightly"]}
+elastic_types_derive = "*"
+
+json_str = { version = "*", features = ["nightly"]}

--- a/samples/typed/src/main.rs
+++ b/samples/typed/src/main.rs
@@ -10,14 +10,14 @@
 
 extern crate serde;
 extern crate serde_json;
-
+extern crate reqwest;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate elastic_types_derive;
 
 #[macro_use]
 extern crate elastic_types;
+#[macro_use]
+extern crate elastic_types_derive;
 extern crate elastic_reqwest;
 extern crate elastic_requests;
 

--- a/samples/typed/src/main.rs
+++ b/samples/typed/src/main.rs
@@ -10,7 +10,6 @@
 
 extern crate serde;
 extern crate serde_json;
-extern crate reqwest;
 
 #[macro_use]
 extern crate serde_derive;
@@ -37,10 +36,7 @@ const INDEX: &'static str = "testidx";
 
 fn main() {
     // Create a new client
-    let (client, _) = elastic_reqwest::default().unwrap();
-
-    // Default request parameters
-    let params = RequestParams::default();
+    let (client, params) = elastic_reqwest::default().unwrap();
 
     // Wait for refresh when indexing data.
     // Normally this isn't a good idea, but is ok for this example.


### PR DESCRIPTION
Adds a sample sending a bulk request. This is basically the code I've used to check whether request bodies are copied in #13.

Hopefully the bit of infrastructure I've got for checking multiple request types isn't too confusing for new users who might not be familiar with `#[cfg]`, or `lazy_static` or allocators.