### PR TITLE
Feat/api tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "elastic_reqwest"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>", "Stephan Buys <stephan.buys@gmail.com>"]
 license = "Apache-2.0"
 description = "A lightweight implementation of the Elasticsearch API based on reqwest."
-documentation = "https://docs.rs/elastic_reqwest/0.1.2/elastic_reqwest/"
+documentation = "https://docs.rs/elastic_reqwest/0.2.0/elastic_reqwest/"
 repository = "https://github.com/elastic-rs/elastic-hyper"
 exclude = [ "samples" ]
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ elastic_requests = "*"
 elastic_reqwest = "*"
 reqwest = "*"
 
-# Optional
+# Optional for request bodies
 json_str = "*"
 ```
 

--- a/samples/basic/src/main.rs
+++ b/samples/basic/src/main.rs
@@ -7,6 +7,7 @@
 
 #[macro_use]
 extern crate json_str;
+#[macro_use]
 extern crate elastic_reqwest;
 extern crate elastic_requests;
 
@@ -19,8 +20,8 @@ fn main() {
     let (client, _) = elastic_reqwest::default().unwrap();
 
     // Create a new set of params with pretty printing.
-    let params = RequestParams::default().
-        url_params(vec![("pretty", String::from("true"))]);
+    let params = RequestParams::default()
+        .url_params(params![pretty: true]);
 
     // Create a query DSL request body.
     let body = json_str!({

--- a/samples/basic/src/main.rs
+++ b/samples/basic/src/main.rs
@@ -7,7 +7,6 @@
 
 #[macro_use]
 extern crate json_str;
-#[macro_use]
 extern crate elastic_reqwest;
 extern crate elastic_requests;
 

--- a/samples/basic/src/main.rs
+++ b/samples/basic/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
 
     // Create a new set of params with pretty printing.
     let params = RequestParams::default()
-        .url_params(params![pretty: true]);
+        .url_param("pretty", true);
 
     // Create a query DSL request body.
     let body = json_str!({

--- a/samples/typed/src/main.rs
+++ b/samples/typed/src/main.rs
@@ -18,6 +18,7 @@ extern crate serde_derive;
 extern crate elastic_types;
 #[macro_use]
 extern crate elastic_types_derive;
+#[macro_use]
 extern crate elastic_reqwest;
 extern crate elastic_requests;
 
@@ -40,7 +41,8 @@ fn main() {
 
     // Wait for refresh when indexing data.
     // Normally this isn't a good idea, but is ok for this example.
-    let index_params = RequestParams::default().url_params(vec![("refresh", String::from("true"))]);
+    let index_params = RequestParams::default()
+        .url_params(params![refresh: true]);
 
     // Create an index and map our type
     create_index(&client, &params);

--- a/samples/typed/src/main.rs
+++ b/samples/typed/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
     // Wait for refresh when indexing data.
     // Normally this isn't a good idea, but is ok for this example.
     let index_params = RequestParams::default()
-        .url_param(refresh, true);
+        .url_param("refresh", true);
 
     // Create an index and map our type
     create_index(&client, &params);

--- a/samples/typed/src/main.rs
+++ b/samples/typed/src/main.rs
@@ -18,7 +18,6 @@ extern crate serde_derive;
 extern crate elastic_types;
 #[macro_use]
 extern crate elastic_types_derive;
-#[macro_use]
 extern crate elastic_reqwest;
 extern crate elastic_requests;
 

--- a/samples/typed/src/main.rs
+++ b/samples/typed/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
     // Wait for refresh when indexing data.
     // Normally this isn't a good idea, but is ok for this example.
     let index_params = RequestParams::default()
-        .url_params(params![refresh: true]);
+        .url_param(refresh, true);
 
     // Create an index and map our type
     create_index(&client, &params);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //! let (client, _) = cli::default().unwrap();
 //!
 //! let params = RequestParams::default()
-//!     .url_param("pretty", "true")
+//!     .url_param("pretty", true)
 //!     .url_param("q", "*");
 //!
 //! let search = SimpleSearchRequest::for_index_ty(
@@ -215,7 +215,7 @@ use url::form_urlencoded::Serializer;
 ///
 /// # fn main() {
 /// let params = elastic::RequestParams::default()
-///     .url_param("pretty", "true")
+///     .url_param("pretty", true)
 ///     .url_param("q", "*");
 /// # }
 /// ```
@@ -243,14 +243,14 @@ impl RequestParams {
     }
 
     /// Set a url param value.
-    pub fn url_param<T: Into<String>>(mut self, key: &'static str, value: T) -> Self
+    pub fn url_param<T: ToString>(mut self, key: &'static str, value: T) -> Self
     {
         if self.url_params.contains_key(key) {
             let mut entry = self.url_params.get_mut(key).unwrap();
-            *entry = value.into();
+            *entry = value.to_string();
         }
         else {
-            self.url_params.insert(key, value.into());
+            self.url_params.insert(key, value.to_string());
         }
 
         self

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,5 +1,6 @@
 extern crate reqwest;
 extern crate url;
+#[macro_use]
 extern crate elastic_reqwest;
 
 use reqwest::header::*;
@@ -21,9 +22,9 @@ fn request_params_has_default_base_url() {
 #[test]
 fn request_params_has_url_query() {
 	let req = RequestParams::default()
-		.url_params(vec![
-			("pretty", "true".to_owned()),
-			("q", "*".to_owned())
+		.url_params(params![
+			pretty: true,
+			q: "*"
 		]);
 
 	assert_eq!((16, Some(String::from("?pretty=true&q=*"))), req.get_url_qry());

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,6 +1,5 @@
 extern crate reqwest;
 extern crate url;
-#[macro_use]
 extern crate elastic_reqwest;
 
 use reqwest::header::*;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -22,10 +22,9 @@ fn request_params_has_default_base_url() {
 #[test]
 fn request_params_has_url_query() {
 	let req = RequestParams::default()
-		.url_params(params![
-			pretty: true,
-			q: "*"
-		]);
+		.url_param("pretty", "false")
+		.url_param("pretty", "true")
+		.url_param("q", "*");
 
 	assert_eq!((16, Some(String::from("?pretty=true&q=*"))), req.get_url_qry());
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -22,8 +22,8 @@ fn request_params_has_default_base_url() {
 #[test]
 fn request_params_has_url_query() {
 	let req = RequestParams::default()
-		.url_param("pretty", "false")
-		.url_param("pretty", "true")
+		.url_param("pretty", false)
+		.url_param("pretty", true)
 		.url_param("q", "*");
 
 	assert_eq!((16, Some(String::from("?pretty=true&q=*"))), req.get_url_qry());


### PR DESCRIPTION
Some tweaks to the API that should make it a bit nicer to work with. Changes include:

- Align `url_param` builder method with `header` builder method
- Use `ToString` bound on the `url_param` value so other types can be passed in
- Don't take headers in the params constructor