### PR TITLE
Set url in builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "elastic_reqwest"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>", "Stephan Buys <stephan.buys@gmail.com>"]
 license = "Apache-2.0"
 description = "A lightweight implementation of the Elasticsearch API based on reqwest."
-documentation = "https://docs.rs/elastic_reqwest/0.2.1/elastic_reqwest/"
+documentation = "https://docs.rs/elastic_reqwest/0.2.2/elastic_reqwest/"
 repository = "https://github.com/elastic-rs/elastic-hyper"
 exclude = [ "samples" ]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,13 @@ impl RequestParams {
         }
     }
 
+    /// Set the base url for the node.
+    pub fn base_url<T: Into<String>>(mut self, base: T) -> Self {
+        self.base_url = base.into();
+
+        self
+    }
+
     /// Set a url param value.
     pub fn url_param<T: ToString>(mut self, key: &'static str, value: T) -> Self
     {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -19,7 +19,15 @@ fn request_params_has_default_base_url() {
 }
 
 #[test]
-fn request_params_has_url_query() {
+fn request_params_can_set_base_url() {
+	let req = RequestParams::default()
+		.base_url("http://eshost:9200");
+
+	assert_eq!("http://eshost:9200", req.base_url);
+}
+
+#[test]
+fn request_params_can_set_url_query() {
 	let req = RequestParams::default()
 		.url_param("pretty", false)
 		.url_param("pretty", true)


### PR DESCRIPTION
This adds a `base_url` builder method to `RequestParams` so you can set it the same way as other parameters.