### PR TITLE
Update reqwest and re-export request types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_reqwest"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>", "Stephan Buys <stephan.buys@gmail.com>"]
 license = "Apache-2.0"
 description = "A lightweight implementation of the Elasticsearch API based on reqwest."
@@ -10,7 +10,7 @@ exclude = [ "samples" ]
 
 [dependencies]
 elastic_requests = "~0.1.3"
-reqwest = "~0.2.0"
+reqwest = "~0.3.0"
 url = "~1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Add `elastic_reqwest` and `json_str` to your `Cargo.toml`:
 
 ```
 [dependencies]
-elastic_requests = "*"
 elastic_reqwest = "*"
 reqwest = "*"
 
@@ -45,12 +44,11 @@ json_str = "*"
 Ping the availability of your cluster:
 
 ```rust
-extern crate elastic_requests as req;
 extern crate elastic_reqwest as cli;
 extern crate reqwest;
 
 use cli::ElasticClient;
-use req::PingRequest;
+use cli::req::PingRequest;
 
 let (client, params) = cli::default().unwrap();
 
@@ -69,12 +67,11 @@ A query DSL query:
 ```rust
 #[macro_use]
 extern crate json_str;
-extern crate elastic_requests as req;
 extern crate elastic_reqwest as cli;
 extern crate reqwest;
 
 use cli::ElasticClient;
-use req::SearchRequest;
+use cli::req::SearchRequest;
  
 let (client, params) = cli::default().unwrap();
 

--- a/samples/basic/Cargo.toml
+++ b/samples/basic/Cargo.toml
@@ -5,6 +5,5 @@ authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 
 [dependencies]
 elastic_reqwest = { version = "*", path = "../../" }
-elastic_requests = "*"
 
 json_str = "*"

--- a/samples/basic/src/main.rs
+++ b/samples/basic/src/main.rs
@@ -7,16 +7,15 @@
 
 #[macro_use]
 extern crate json_str;
-extern crate elastic_reqwest;
-extern crate elastic_requests;
+extern crate elastic_reqwest as cli;
 
-use elastic_reqwest::{ElasticClient, RequestParams};
-use elastic_requests::SearchRequest;
+use cli::{ElasticClient, RequestParams};
+use cli::req::SearchRequest;
 use std::io::Read;
 
 fn main() {
     // Get a new default client.
-    let (client, _) = elastic_reqwest::default().unwrap();
+    let (client, _) = cli::default().unwrap();
 
     // Create a new set of params with pretty printing.
     let params = RequestParams::default()

--- a/samples/bulk/Cargo.toml
+++ b/samples/bulk/Cargo.toml
@@ -8,6 +8,5 @@ profiling = []
 
 [dependencies]
 elastic_reqwest = { version = "*", path = "../../" }
-elastic_requests = "*"
 
 lazy_static = { version = "*", optional = true }

--- a/samples/bulk/src/main.rs
+++ b/samples/bulk/src/main.rs
@@ -20,11 +20,10 @@ extern crate alloc_system;
 #[cfg_attr(feature = "lazy_static", macro_use)]
 extern crate lazy_static;
 
-extern crate elastic_requests;
-extern crate elastic_reqwest;
+extern crate elastic_reqwest as cli;
 
-use elastic_reqwest::ElasticClient;
-use elastic_requests::BulkRequest;
+use cli::ElasticClient;
+use cli::req::BulkRequest;
 
 // Create a bulk request to index a bunch of docs.
 macro_rules! bulk_req {
@@ -63,7 +62,7 @@ fn get_req() -> &'static BulkRequest<'static> {
 
 fn main() {
     // Get a new default client.
-    let (client, params) = elastic_reqwest::default().unwrap();
+    let (client, params) = cli::default().unwrap();
 
     // Send the bulk request.
     let res = client.elastic_req(&params, get_req()).unwrap();

--- a/samples/typed/Cargo.toml
+++ b/samples/typed/Cargo.toml
@@ -5,9 +5,8 @@ authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 
 [dependencies]
 elastic_reqwest = { version = "*", path = "../../" }
-elastic_requests = "*"
 
-reqwest = "~0.2.0"
+reqwest = "~0.3.0"
 serde = "~0.8.0"
 serde_derive = "~0.8.0"
 serde_json = "~0.8.0"

--- a/samples/typed/src/main.rs
+++ b/samples/typed/src/main.rs
@@ -14,17 +14,15 @@ extern crate reqwest;
 #[macro_use]
 extern crate serde_derive;
 
-#[macro_use]
 extern crate elastic_types;
 #[macro_use]
 extern crate elastic_types_derive;
-extern crate elastic_reqwest;
-extern crate elastic_requests;
+extern crate elastic_reqwest as cli;
 
 use std::net::Ipv4Addr;
 use reqwest::Client;
-use elastic_reqwest::{ElasticClient, RequestParams};
-use elastic_requests::{IndicesCreateRequest, IndexRequest, SearchRequest};
+use cli::{ElasticClient, RequestParams};
+use cli::req::{IndicesCreateRequest, IndexRequest, SearchRequest};
 use elastic_types::prelude::*;
 
 mod data;
@@ -36,7 +34,7 @@ const INDEX: &'static str = "testidx";
 
 fn main() {
     // Create a new client
-    let (client, params) = elastic_reqwest::default().unwrap();
+    let (client, params) = cli::default().unwrap();
 
     // Wait for refresh when indexing data.
     // Normally this isn't a good idea, but is ok for this example.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,23 +23,13 @@
 //!
 //! ```ignore
 //! [dependencies]
-//! elastic_requests = "*"
 //! elastic_reqwest = "*"
 //! reqwest = "*"
-//! ```
-//!
-//! For `Windows`, you may need to exclude `openssl` or the build can fail:
-//!
-//! ```ignore
-//! [dependencies]
-//! elastic_requests = "*"
-//! elastic_reqwest = { version = "*", default-features = false }
 //! ```
 //!
 //! Then reference in your crate root:
 //!
 //! ```
-//! extern crate elastic_requests as req;
 //! extern crate elastic_reqwest as cli;
 //! ```
 //!
@@ -50,10 +40,9 @@
 //! ```no_run
 //! //HTTP HEAD /
 //!
-//! # extern crate elastic_requests as req;
 //! # extern crate elastic_reqwest as cli;
 //! use cli::ElasticClient;
-//! use req::PingRequest;
+//! use cli::req::PingRequest;
 //!
 //! # fn main() {
 //! let (client, params) = cli::default().unwrap();
@@ -70,10 +59,9 @@
 //! //HTTP GET /myindex/mytype/_search?q='my string'
 //!
 //! extern crate reqwest;
-//! extern crate elastic_requests as req;
 //! extern crate elastic_reqwest as cli;
 //! use cli::{ ElasticClient, RequestParams };
-//! use req::SimpleSearchRequest;
+//! use cli::req::SimpleSearchRequest;
 //!
 //! # fn main() {
 //! let (client, _) = cli::default().unwrap();
@@ -101,10 +89,9 @@
 //! #
 //! #[macro_use]
 //! extern crate json_str;
-//! extern crate elastic_requests as req;
 //! extern crate elastic_reqwest as cli;
 //! use cli::ElasticClient;
-//! use req::SearchRequest;
+//! use cli::req::SearchRequest;
 //!
 //! # fn main() {
 //! let (client, params) = cli::default().unwrap();
@@ -159,7 +146,6 @@ extern crate elastic_requests;
 extern crate reqwest;
 extern crate url;
 
-use elastic_requests::*;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::io::Cursor;
@@ -167,6 +153,15 @@ use std::str;
 use reqwest::header::{Header, HeaderFormat, Headers, ContentType};
 use reqwest::Response;
 use url::form_urlencoded::Serializer;
+
+/// Request types.
+/// 
+/// These are re-exported from `elastic_requests` for convenience.
+pub mod req {
+    pub use elastic_requests::*;
+}
+
+use self::req::{HttpRequest, HttpMethod, RawBody};
 
 /// Misc parameters for any request.
 ///


### PR DESCRIPTION
Closes #9 and #18 

Updates to the current version of `reqwest` and re-exports `elastic_requests` under a `req` module so you don't need to reference both crates anymore.