### PR TITLE
Add an Error type to IntoBody

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_reqwest"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>", "Stephan Buys <stephan.buys@gmail.com>"]
 license = "Apache-2.0"
 description = "A lightweight implementation of the Elasticsearch API based on reqwest."
@@ -13,7 +13,7 @@ nightly = []
 
 [dependencies]
 elastic_requests = "~0.4.1"
-reqwest = "~0.4.0"
+reqwest = "~0.6.0"
 url = "~1"
 
 [dev-dependencies]


### PR DESCRIPTION
Closes #38 

- Add an `Error` associated type to `IntoBody` so upstream crates can implement for things like `serde::Deserialize`.
- Adds an `Error` type

`reqwest` does actually support `serde_json` out of the box, but it keeps our glue simpler to assume that isn't the case.