### PR TITLE
Update to elastic_types 0.18.0

### DIFF
--- a/examples/typed/Cargo.toml
+++ b/examples/typed/Cargo.toml
@@ -10,7 +10,7 @@ reqwest = "~0.6"
 serde = "~1"
 serde_derive = "~1"
 serde_json = "~1"
-elastic_types = "~0.17"
-elastic_types_derive = "~0.17"
+elastic_types = "~0.18"
+elastic_types_derive = "~0.18"
 
 json_str = { version = "*", features = ["nightly"]}


### PR DESCRIPTION
Fixes an issue with the yanked `0.3.1` version of `chrono`. This is just in an example, so doesn't affect `elastic_reqwest` proper.